### PR TITLE
Php8.4 update

### DIFF
--- a/src/HttpCode.php
+++ b/src/HttpCode.php
@@ -483,7 +483,7 @@ class HttpCode
      */
     public static function isValid($codeToCheck): bool
     {
-        $c = new ReflectionClass(get_class());
+        $c = new ReflectionClass(get_class($this));
         $statusCodes = $c->getConstants(); // class constants
 
         return in_array($codeToCheck, $statusCodes);

--- a/src/HttpCode.php
+++ b/src/HttpCode.php
@@ -483,7 +483,8 @@ class HttpCode
      */
     public static function isValid($codeToCheck): bool
     {
-        $c = new ReflectionClass(get_class($this));
+        $obj = new HttpCode();
+        $c = new ReflectionClass(get_class($obj));
         $statusCodes = $c->getConstants(); // class constants
 
         return in_array($codeToCheck, $statusCodes);


### PR DESCRIPTION
get_class() must now be provided with an object. See changelog: https://www.php.net/manual/en/function.get-class.php